### PR TITLE
Support for Svg elements

### DIFF
--- a/source/WebElements.ts
+++ b/source/WebElements.ts
@@ -4,9 +4,9 @@
 // MIT License: https://raw.githubusercontent.com/nezaboodka/reactronic-front-web/master/LICENSE
 
 import { Render, Emitted, emit, RenderWithParent, Customize } from 'reactronic-front'
-import { WebRtti } from './WebRtti'
+import { WebRtti, WebSvgRtti } from './WebRtti'
 
-function nullRender(e: HTMLElement): void { /* nop */ }
+function nullRender(e: Element): void { /* nop */ }
 
 export function RxDiv<O = void, S = void>(id: string, state: S, render: Render<HTMLDivElement, O, S>, customize?: Customize<O, HTMLDivElement, S>): Emitted<HTMLDivElement, O, S> { return emit(id, state, render, customize, Html.div) }
 export function RxSpan<O = void, S = void>(id: string, state: S, render: Render<HTMLSpanElement, O, S>, customize?: Customize<O, HTMLSpanElement, S>): Emitted<HTMLSpanElement, O, S> { return emit(id, state, render, customize, Html.span) }
@@ -89,4 +89,90 @@ const Html = {
   th: new WebRtti<HTMLTableHeaderCellElement>('th'),
   td: new WebRtti<HTMLTableDataCellElement>('td'),
   caption: new WebRtti<HTMLTableCaptionElement>('caption'),
+}
+
+export function RxSvg<O = void, S = void>(id: string, state: S, render: Render<SVGSVGElement, O, S>, customize?: Customize<O, SVGSVGElement, S>): Emitted<SVGSVGElement, O, S> { return emit(id, state, render, customize, Svg.svg) }
+export function RxSvgLink<O = void, S = void>(id: string, state: S, render: Render<SVGAElement, O, S>, customize?: Customize<O, SVGAElement, S>): Emitted<SVGAElement, O, S> { return emit(id, state, render, customize, Svg.svgLink) }
+export function RxAnimate<O = void, S = void>(id: string, state: S, render: Render<SVGAnimateElement, O, S>, customize?: Customize<O, SVGAnimateElement, S>): Emitted<SVGAnimateElement, O, S> { return emit(id, state, render, customize, Svg.animate) }
+export function RxAnimateMotion<O = void, S = void>(id: string, state: S, render: Render<SVGAnimateMotionElement, O, S>, customize?: Customize<O, SVGAnimateMotionElement, S>): Emitted<SVGAnimateMotionElement, O, S> { return emit(id, state, render, customize, Svg.animateMotion) }
+export function RxAnimateTransform<O = void, S = void>(id: string, state: S, render: Render<SVGAnimateTransformElement, O, S>, customize?: Customize<O, SVGAnimateTransformElement, S>): Emitted<SVGAnimateTransformElement, O, S> { return emit(id, state, render, customize, Svg.animateTransform) }
+export function RxCircle<O = void, S = void>(id: string, state: S, render: Render<SVGCircleElement, O, S>, customize?: Customize<O, SVGCircleElement, S>): Emitted<SVGCircleElement, O, S> { return emit(id, state, render, customize, Svg.circle) }
+export function RxClipPath<O = void, S = void>(id: string, state: S, render: Render<SVGClipPathElement, O, S>, customize?: Customize<O, SVGClipPathElement, S>): Emitted<SVGClipPathElement, O, S> { return emit(id, state, render, customize, Svg.clipPath) }
+export function RxDefs<O = void, S = void>(id: string, state: S, render: Render<SVGDefsElement, O, S>, customize?: Customize<O, SVGDefsElement, S>): Emitted<SVGDefsElement, O, S> { return emit(id, state, render, customize, Svg.defs) }
+export function RxDesc<O = void, S = void>(id: string, state: S, render: Render<SVGDescElement, O, S>, customize?: Customize<O, SVGDescElement, S>): Emitted<SVGDescElement, O, S> { return emit(id, state, render, customize, Svg.desc) }
+export function RxEllipse<O = void, S = void>(id: string, state: S, render: Render<SVGEllipseElement, O, S>, customize?: Customize<O, SVGEllipseElement, S>): Emitted<SVGEllipseElement, O, S> { return emit(id, state, render, customize, Svg.ellipse) }
+export function RxForeignObject<O = void, S = void>(id: string, state: S, render: Render<SVGForeignObjectElement, O, S>, customize?: Customize<O, SVGForeignObjectElement, S>): Emitted<SVGForeignObjectElement, O, S> { return emit(id, state, render, customize, Svg.foreignObject) }
+export function RxG<O = void, S = void>(id: string, state: S, render: Render<SVGGElement, O, S>, customize?: Customize<O, SVGGElement, S>): Emitted<SVGGElement, O, S> { return emit(id, state, render, customize, Svg.g) }
+export function RxSvgImage<O = void, S = void>(id: string, state: S, render: Render<SVGImageElement, O, S>, customize?: Customize<O, SVGImageElement, S>): Emitted<SVGImageElement, O, S> { return emit(id, state, render, customize, Svg.svgImage) }
+export function RxLine<O = void, S = void>(id: string, state: S, render: Render<SVGLineElement, O, S>, customize?: Customize<O, SVGLineElement, S>): Emitted<SVGLineElement, O, S> { return emit(id, state, render, customize, Svg.line) }
+export function RxLinearGradient<O = void, S = void>(id: string, state: S, render: Render<SVGLinearGradientElement, O, S>, customize?: Customize<O, SVGLinearGradientElement, S>): Emitted<SVGLinearGradientElement, O, S> { return emit(id, state, render, customize, Svg.linearGradient) }
+export function RxMarker<O = void, S = void>(id: string, state: S, render: Render<SVGMarkerElement, O, S>, customize?: Customize<O, SVGMarkerElement, S>): Emitted<SVGMarkerElement, O, S> { return emit(id, state, render, customize, Svg.marker) }
+export function RxMask<O = void, S = void>(id: string, state: S, render: Render<SVGMaskElement, O, S>, customize?: Customize<O, SVGMaskElement, S>): Emitted<SVGMaskElement, O, S> { return emit(id, state, render, customize, Svg.mask) }
+export function RxPath<O = void, S = void>(id: string, state: S, render: Render<SVGPathElement, O, S>, customize?: Customize<O, SVGPathElement, S>): Emitted<SVGPathElement, O, S> { return emit(id, state, render, customize, Svg.path) }
+export function RxPattern<O = void, S = void>(id: string, state: S, render: Render<SVGPatternElement, O, S>, customize?: Customize<O, SVGPatternElement, S>): Emitted<SVGPatternElement, O, S> { return emit(id, state, render, customize, Svg.pattern) }
+export function RxPolygon<O = void, S = void>(id: string, state: S, render: Render<SVGPolygonElement, O, S>, customize?: Customize<O, SVGPolygonElement, S>): Emitted<SVGPolygonElement, O, S> { return emit(id, state, render, customize, Svg.polygon) }
+export function RxPolyline<O = void, S = void>(id: string, state: S, render: Render<SVGPolylineElement, O, S>, customize?: Customize<O, SVGPolylineElement, S>): Emitted<SVGPolylineElement, O, S> { return emit(id, state, render, customize, Svg.polyline) }
+export function RxRadialGradient<O = void, S = void>(id: string, state: S, render: Render<SVGRadialGradientElement, O, S>, customize?: Customize<O, SVGRadialGradientElement, S>): Emitted<SVGRadialGradientElement, O, S> { return emit(id, state, render, customize, Svg.radialGradient) }
+export function RxRect<O = void, S = void>(id: string, state: S, render: Render<SVGRectElement, O, S>, customize?: Customize<O, SVGRectElement, S>): Emitted<SVGRectElement, O, S> { return emit(id, state, render, customize, Svg.rect) }
+export function RxText<O = void, S = void>(id: string, state: S, render: Render<SVGTextElement, O, S>, customize?: Customize<O, SVGTextElement, S>): Emitted<SVGTextElement, O, S> { return emit(id, state, render, customize, Svg.text) }
+export function RxTextPath<O = void, S = void>(id: string, state: S, render: Render<SVGTextPathElement, O, S>, customize?: Customize<O, SVGTextPathElement, S>): Emitted<SVGTextPathElement, O, S> { return emit(id, state, render, customize, Svg.textPath) }
+export function RxUse<O = void, S = void>(id: string, state: S, render: Render<SVGUseElement, O, S>, customize?: Customize<O, SVGUseElement, S>): Emitted<SVGUseElement, O, S> { return emit(id, state, render, customize, Svg.use) }
+export function RxView<O = void, S = void>(id: string, state: S, render: Render<SVGViewElement, O, S>, customize?: Customize<O, SVGViewElement, S>): Emitted<SVGViewElement, O, S> { return emit(id, state, render, customize, Svg.view) }
+
+export function svg(id: string, render: Render<SVGSVGElement> = nullRender): Emitted<SVGSVGElement> { return emit(id, RenderWithParent, render, undefined, Svg.svg) }
+export function svgLink(id: string, render: Render<SVGAElement> = nullRender): Emitted<SVGAElement> { return emit(id, RenderWithParent, render, undefined, Svg.link) }
+export function animate(id: string, render: Render<SVGAnimateElement> = nullRender): Emitted<SVGAnimateElement> { return emit(id, RenderWithParent, render, undefined, Svg.animate) }
+export function animateMotion(id: string, render: Render<SVGAnimateMotionElement> = nullRender): Emitted<SVGAnimateMotionElement> { return emit(id, RenderWithParent, render, undefined, Svg.animateMotion) }
+export function animateTransform(id: string, render: Render<SVGAnimateTransformElement> = nullRender): Emitted<SVGAnimateTransformElement> { return emit(id, RenderWithParent, render, undefined, Svg.animateTransform) }
+export function circle(id: string, render: Render<SVGCircleElement> = nullRender): Emitted<SVGCircleElement> { return emit(id, RenderWithParent, render, undefined, Svg.circle) }
+export function clipPath(id: string, render: Render<SVGClipPathElement> = nullRender): Emitted<SVGClipPathElement> { return emit(id, RenderWithParent, render, undefined, Svg.clipPath) }
+export function defs(id: string, render: Render<SVGDefsElement> = nullRender): Emitted<SVGDefsElement> { return emit(id, RenderWithParent, render, undefined, Svg.defs) }
+export function desc(id: string, render: Render<SVGDescElement> = nullRender): Emitted<SVGDescElement> { return emit(id, RenderWithParent, render, undefined, Svg.desc) }
+export function ellipse(id: string, render: Render<SVGEllipseElement> = nullRender): Emitted<SVGEllipseElement> { return emit(id, RenderWithParent, render, undefined, Svg.ellipse) }
+export function foreignObject(id: string, render: Render<SVGForeignObjectElement> = nullRender): Emitted<SVGForeignObjectElement> { return emit(id, RenderWithParent, render, undefined, Svg.foreignObject) }
+export function g(id: string, render: Render<SVGGElement> = nullRender): Emitted<SVGGElement> { return emit(id, RenderWithParent, render, undefined, Svg.g) }
+export function svgImage(id: string, render: Render<SVGImageElement> = nullRender): Emitted<SVGImageElement> { return emit(id, RenderWithParent, render, undefined, Svg.image) }
+export function line(id: string, render: Render<SVGLineElement> = nullRender): Emitted<SVGLineElement> { return emit(id, RenderWithParent, render, undefined, Svg.line) }
+export function linearGradient(id: string, render: Render<SVGLinearGradientElement> = nullRender): Emitted<SVGLinearGradientElement> { return emit(id, RenderWithParent, render, undefined, Svg.linearGradient) }
+export function marker(id: string, render: Render<SVGMarkerElement> = nullRender): Emitted<SVGMarkerElement> { return emit(id, RenderWithParent, render, undefined, Svg.marker) }
+export function mask(id: string, render: Render<SVGMaskElement> = nullRender): Emitted<SVGMaskElement> { return emit(id, RenderWithParent, render, undefined, Svg.mask) }
+export function path(id: string, render: Render<SVGPathElement> = nullRender): Emitted<SVGPathElement> { return emit(id, RenderWithParent, render, undefined, Svg.path) }
+export function pattern(id: string, render: Render<SVGPatternElement> = nullRender): Emitted<SVGPatternElement> { return emit(id, RenderWithParent, render, undefined, Svg.pattern) }
+export function polygon(id: string, render: Render<SVGPolygonElement> = nullRender): Emitted<SVGPolygonElement> { return emit(id, RenderWithParent, render, undefined, Svg.polygon) }
+export function polyline(id: string, render: Render<SVGPolylineElement> = nullRender): Emitted<SVGPolylineElement> { return emit(id, RenderWithParent, render, undefined, Svg.polyline) }
+export function radialGradient(id: string, render: Render<SVGRadialGradientElement> = nullRender): Emitted<SVGRadialGradientElement> { return emit(id, RenderWithParent, render, undefined, Svg.radialGradient) }
+export function rect(id: string, render: Render<SVGRectElement> = nullRender): Emitted<SVGRectElement> { return emit(id, RenderWithParent, render, undefined, Svg.rect) }
+export function text(id: string, render: Render<SVGTextElement> = nullRender): Emitted<SVGTextElement> { return emit(id, RenderWithParent, render, undefined, Svg.text) }
+export function textPath(id: string, render: Render<SVGTextPathElement> = nullRender): Emitted<SVGTextPathElement> { return emit(id, RenderWithParent, render, undefined, Svg.textPath) }
+export function use(id: string, render: Render<SVGUseElement> = nullRender): Emitted<SVGUseElement> { return emit(id, RenderWithParent, render, undefined, Svg.use) }
+export function view(id: string, render: Render<SVGViewElement> = nullRender): Emitted<SVGViewElement> { return emit(id, RenderWithParent, render, undefined, Svg.view) }
+
+const Svg = {
+  svg: new WebSvgRtti<SVGSVGElement>('svg'),
+  link: new WebSvgRtti<SVGAElement>('a'),
+  animate: new WebSvgRtti<SVGAnimateElement>('animate'),
+  animateMotion: new WebSvgRtti<SVGAnimateMotionElement>('animateMotion'),
+  animateTransform: new WebSvgRtti<SVGAnimateTransformElement>('animateTransform'),
+  circle: new WebSvgRtti<SVGCircleElement>('circle'),
+  clipPath: new WebSvgRtti<SVGClipPathElement>('clipPath'),
+  defs: new WebSvgRtti<SVGDefsElement>('defs'),
+  desc: new WebSvgRtti<SVGDescElement>('desc'),
+  ellipse: new WebSvgRtti<SVGEllipseElement>('ellipse'),
+  foreignObject: new WebSvgRtti<SVGForeignObjectElement>('foreignObject'),
+  g: new WebSvgRtti<SVGGElement>('g'),
+  image: new WebSvgRtti<SVGImageElement>('image'),
+  line: new WebSvgRtti<SVGLineElement>('line'),
+  linearGradient: new WebSvgRtti<SVGLinearGradientElement>('linearGradient'),
+  marker: new WebSvgRtti<SVGMarkerElement>('marker'),
+  mask: new WebSvgRtti<SVGMaskElement>('mask'),
+  path: new WebSvgRtti<SVGPathElement>('path'),
+  pattern: new WebSvgRtti<SVGPatternElement>('pattern'),
+  polygon: new WebSvgRtti<SVGPolygonElement>('polygon'),
+  polyline: new WebSvgRtti<SVGPolylineElement>('polyline'),
+  radialGradient: new WebSvgRtti<SVGRadialGradientElement>('radialGradient'),
+  rect: new WebSvgRtti<SVGRectElement>('rect'),
+  text: new WebSvgRtti<SVGTextElement>('text'),
+  textPath: new WebSvgRtti<SVGTextPathElement>('textPath'),
+  use: new WebSvgRtti<SVGUseElement>('use'),
+  view: new WebSvgRtti<SVGViewElement>('view'),
 }

--- a/source/WebRtti.ts
+++ b/source/WebRtti.ts
@@ -7,16 +7,16 @@ import { Reactronic } from 'reactronic'
 import { render, unmount, Emitted, Rtti } from 'reactronic-front'
 
 export function usingParent<T>(e: HTMLElement, func: (...args: any[]) => T, ...args: any[]): T {
-  const outer = WebRtti.current
+  const outer = WebElementRtti.current
   try {
     return func(...args)
   }
   finally {
-    WebRtti.current = outer
+    WebElementRtti.current = outer
   }
 }
 
-export class WebRtti<E extends HTMLElement> implements Rtti<E, any, any> {
+abstract class WebElementRtti<E extends Element> implements Rtti<E, any, any> {
   static isDebugAttributeEnabled: boolean = false
 
   constructor(
@@ -25,29 +25,29 @@ export class WebRtti<E extends HTMLElement> implements Rtti<E, any, any> {
   }
 
   render(e: Emitted<E, any, any>): void {
-    const outer = WebRtti.current
+    const outer = WebElementRtti.current
     try { // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const mounted = e.mounted! // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const native = mounted.instance!.native!
-      WebRtti.current = native // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}render(${e.id} r${ref.mounted!.cycle})`)
+      WebElementRtti.current = native // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}render(${e.id} r${ref.mounted!.cycle})`)
       render(e) // proceed
-      WebRtti.blinkingEffect && blink(native, mounted.cycle)
-      if (WebRtti.isDebugAttributeEnabled)
+      WebElementRtti.blinkingEffect && blink(native, mounted.cycle)
+      if (WebElementRtti.isDebugAttributeEnabled)
         native.setAttribute('rdbg', `${mounted.cycle}:    ${Reactronic.why()}`)
     }
     finally {
-      WebRtti.current = outer
+      WebElementRtti.current = outer
     }
   }
 
   mount(e: Emitted<E, any, any>, owner: Emitted, sibling?: Emitted): void {
-    const parent = owner.mounted?.instance?.native as HTMLElement ?? WebRtti.current // TODO: To get rid of this workaround
-    const native = document.createElement(e.rtti.name) as E // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const parent = owner.mounted?.instance?.native as Element ?? WebElementRtti.current // TODO: To get rid of this workaround
+    const native = this.createElement(e) // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     native.id = e.id // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}${parent.id}.appendChild(${e.id} r${ref.mounted!.cycle})`)
     if (!owner.rtti.sorting) {
       if (sibling !== undefined) {
         const prev = sibling.mounted?.instance?.native
-        if (prev instanceof HTMLElement)
+        if (prev instanceof Element)
           parent.insertBefore(native, prev.nextSibling)
       }
       else
@@ -59,11 +59,13 @@ export class WebRtti<E extends HTMLElement> implements Rtti<E, any, any> {
     e.mounted!.instance!.native = native
   }
 
+  protected abstract createElement(e: Emitted<E, any, any>): E
+
   reorder(e: Emitted<E, any, any>, owner: Emitted, sibling?: Emitted): void {
-    const parent = owner.mounted?.instance?.native as HTMLElement ?? WebRtti.current // TODO: To get rid of this workaround
+    const parent = owner.mounted?.instance?.native as Element ?? WebElementRtti.current // TODO: To get rid of this workaround
     const prev = sibling?.mounted?.instance?.native
     const native = e.mounted?.instance?.native
-    if (native && prev instanceof HTMLElement && prev.nextSibling !== native) { // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (native && prev instanceof Element && prev.nextSibling !== native) { // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}${parent.id}.insertBefore(${(prev.nextSibling! as any)?.id})`)
       parent.insertBefore(native, prev.nextSibling)
     }
@@ -71,14 +73,14 @@ export class WebRtti<E extends HTMLElement> implements Rtti<E, any, any> {
 
   unmount(e: Emitted<E, any, any>, owner: Emitted, cause: Emitted): void {
     const native = e.mounted?.instance?.native
-    if (!WebRtti.unmounting && native && native.parentElement) {
-      WebRtti.unmounting = native // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (!WebElementRtti.unmounting && native && native.parentElement) {
+      WebElementRtti.unmounting = native // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       try { // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}${e.parentElement.id}.removeChild(${e.id} r${ref.mounted!.cycle})`)
         native.remove()
         unmount(e, owner, cause) // proceed
       }
       finally {
-        WebRtti.unmounting = undefined
+        WebElementRtti.unmounting = undefined
       }
     }
     else { // console.log(`${'  '.repeat(Math.abs(ref.mounted!.level))}???.unmount(${ref.id} r${ref.mounted!.cycle})`)
@@ -86,14 +88,26 @@ export class WebRtti<E extends HTMLElement> implements Rtti<E, any, any> {
     }
   }
 
-  static current: HTMLElement = document.body
-  static unmounting?: HTMLElement = undefined
+  static current: Element = document.body
+  static unmounting?: Element = undefined
   static blinkingEffect: string | undefined = undefined
 }
 
-function blink(e: HTMLElement, cycle: number): void {
+function blink(e: Element, cycle: number): void {
   const n1 = cycle % 2 + 1
   const n2 = n1 % 2 + 1
-  e.classList.toggle(`${WebRtti.blinkingEffect}-${n1}`, true)
-  e.classList.toggle(`${WebRtti.blinkingEffect}-${n2}`, false)
+  e.classList.toggle(`${WebElementRtti.blinkingEffect}-${n1}`, true)
+  e.classList.toggle(`${WebElementRtti.blinkingEffect}-${n2}`, false)
+}
+
+export class WebRtti<E extends HTMLElement> extends WebElementRtti<E> {
+  protected createElement(e: Emitted<E, any, any>): E {
+    return document.createElement(e.rtti.name) as E
+  }
+}
+
+export class WebSvgRtti<E extends SVGElement> extends WebElementRtti<E> {
+  protected createElement(e: Emitted<E, any, any>): E {
+    return document.createElementNS('http://www.w3.org/2000/svg', e.rtti.name) as E
+  }
 }


### PR DESCRIPTION
Svg elements can't be created via `document.createElement(...)`. `createElementNS('http://www.w3.org/2000/svg', ...)` should be used instead.

Besides, svg elements inherit `SVGElement` (as opposed to `HTMLElement` for regular tags). `Element` is a common base for both of them.

This PR also adds API for most common svg elements